### PR TITLE
README.mdの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|text|null: false, add_index :users, :name,unique: true|
+|name|string|null: false, add_index :users, :name,unique: true|
 |email|string|null: false, add_index :users, :email,unique: true|
 |password|string|null: false|
 ### Association

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |images|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|text|null: false, add_index :groups, :name,unique: true|
+|name|string|null: false, add_index :groups, :name,unique: true|
 ### Association
 - has_many :messages
 - has_many :groups_users

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |body|text||
-|images|string||
+|image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association

--- a/README.md
+++ b/README.md
@@ -1,24 +1,42 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+# ChatSpace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|text|null: false, add_index :users, :name,unique: true|
+|email|string|null: false, add_index :users, :email,unique: true|
+|password|string|null: false|
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :groups,  through:  : groups_users
 
-Things you may want to cover:
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|text|null: false, add_index :groups, :name,unique: true|
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :users,  through:  : groups_users
 
-* Ruby version
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|tweet_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
 
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|images|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
-|tweet_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false, add_index :groups, :name,unique: true|
+|name|string|null: false|
 ### Association
 - has_many :messages
 - has_many :groups_users


### PR DESCRIPTION
#What
README.mdの実装を行う
ChatSpaceのデータベース設計においてエンティティの洗い出しを行い、users, groups, groups_users, messagesの4つのテーブルの作成が必要だとわかったので、それぞれのテーブルの設計についてREADME.mdに記述した。

#Why
ChatSpaceのデータベース設計の確認をおこなうため